### PR TITLE
Making Erlang ~25% faster

### DIFF
--- a/element-recursion/josephus.erl
+++ b/element-recursion/josephus.erl
@@ -1,11 +1,12 @@
 -module(josephus).
--export([benchmark/0,shout/2]).
+-export([benchmark/0]).
+-compile(native).
 
 shout(Count,Nth) ->
     shout(lists:seq(1,Count),[],Nth,1).
 
 shout([Head | []], [], _, _) -> Head;
-shout([], Survivors, Nth, Counter) -> 
+shout([], Survivors, Nth, Counter) ->
     %% io:format("Reversing~n",[]),
     shout(lists:reverse(Survivors),[], Nth, Counter);
 shout([Head | Tail], Survivors, Nth, 1) ->
@@ -27,7 +28,7 @@ iter(N) ->
 benchmark() ->
     Iter = 1000000,
     iter(Iter),
-    Start = now(),
+    Start = os:timestamp(),
     iter(Iter),
-    End = now(),
+    End = os:timestamp(),
     io:format("Time is ~w microseconds per iteration (element recursive)~n",[timer:now_diff(End,Start) / Iter]).

--- a/list-reduction/josephus.erl
+++ b/list-reduction/josephus.erl
@@ -1,5 +1,6 @@
 -module(josephus).
--export([benchmark/0,shout/2]).
+-export([benchmark/0]).
+-compile(native).
 
 shout(Count,Nth) ->
     shoutList(lists:seq(1,Count),Nth,1).
@@ -12,7 +13,7 @@ shoutList(List,N,Counter) ->
 shoutSubList([],_,Counter,Acc) -> {lists:reverse(Acc),Counter};
 shoutSubList([_Head|Tail], N, 1, Acc) -> shoutSubList(Tail, N, 2, Acc);
 shoutSubList([Head|Tail], N, Counter,Acc) ->
-    NextCounter = 
+    NextCounter =
         if
             Counter =:= N -> 1;
             true -> Counter + 1
@@ -29,7 +30,7 @@ iter(N) ->
 benchmark() ->
     Iter = 1000000,
     iter(Iter),
-    Start = now(),
+    Start = os:timestamp(),
     iter(Iter),
-    End = now(),
+    End = os:timestamp(),
     io:format("Time is ~w microseconds per iteration (list reduction)~n",[timer:now_diff(End,Start) / Iter]).


### PR DESCRIPTION
This is done by:
- changing the way to measure time. Calling now/0 makes the time
  always increase if not necessary. Using os:timestamp/0 makes
  tight measurements better.
- Removing the exports of a few function in conjunction with
  native compiling. This lets the compiler focus more on certain
  types and allows to unbox smaller integers, remove dynamic
  type checks, etc. This gives most of the speedup.
