### PR TITLE
clojure speedups

### DIFF
--- a/list-reduction/josephus.clj
+++ b/list-reduction/josephus.clj
@@ -1,17 +1,26 @@
-(defn shout ^long [counter nth coll]
-  (let [cnt (count coll)]
-    (if (= 1 cnt)
-      (first coll)
-      (shout (rem (+ counter cnt) nth)
-             nth
-             (keep-indexed (fn [index item]
-                             (when-not (zero? (rem (+ index counter)
-                                                   nth))
-                               item))
-                           coll)))))
+(defn shout [^long counter ^long nth [cnt coll]]
+  (if (= 1 cnt)
+    (first coll)
+    (shout (rem (+ counter cnt) nth)
+           nth
+           (loop [index 0
+                  new-count 0
+                  remaining coll
+                  result (transient [])]
+             (if (seq remaining)
+               (if-not (zero? (rem (+ index counter) nth))
+                 (recur (inc index)
+                        (inc new-count)
+                        (rest remaining)
+                        (conj! result (first remaining)))
+                 (recur (inc index)
+                        new-count
+                        (rest remaining)
+                        result))
+               [new-count (persistent! result)])))))
 
 (defn josephus [people nth]
-  (shout 0 nth (into [] (range 1 (inc people)))))
+  (shout 0 nth [people (into [] (range 1 (inc people)))]))
 
 (defn run-iterations [iterations times]
   (dotimes [_ times]

--- a/list-reduction/josephus.clj
+++ b/list-reduction/josephus.clj
@@ -1,28 +1,31 @@
-(defn shout [^long counter ^long nth [cnt coll]]
+(defn shout ^long [^long counter ^long nth ^long cnt coll]
   (if (= 1 cnt)
     (first coll)
-    (shout (rem (+ counter cnt) nth)
-           nth
-           (loop [index 0
-                  new-count 0
-                  remaining coll
-                  result (transient [])]
-             (if (seq remaining)
-               (if-not (zero? (rem (+ index counter) nth))
-                 (recur (inc index)
-                        (inc new-count)
-                        (rest remaining)
-                        (conj! result (first remaining)))
-                 (recur (inc index)
-                        new-count
-                        (rest remaining)
-                        result))
-               [new-count (persistent! result)])))))
+    (let [[new-count result]
+          (loop [index 0
+                 new-count 0
+                 remaining coll
+                 result (transient [])]
+            (if (seq remaining)
+              (if-not (zero? (rem (+ index counter) nth))
+                (recur (inc index)
+                       (inc new-count)
+                       (rest remaining)
+                       (conj! result (first remaining)))
+                (recur (inc index)
+                       new-count
+                       (rest remaining)
+                       result))
+              [new-count (persistent! result)]))]
+      (recur (rem (+ counter cnt) nth)
+             nth
+             (long new-count)
+             result))))
 
-(defn josephus [people nth]
-  (shout 0 nth [people (into [] (range 1 (inc people)))]))
+(defn josephus ^long [^long people ^long nth]
+  (shout 0 nth people (into [] (range 1 (inc people)))))
 
-(defn run-iterations [iterations times]
+(defn run-iterations [^long iterations ^long times]
   (dotimes [_ times]
     (let [start (System/nanoTime)]
         (dotimes[_ iterations] 

--- a/list-reduction/josephus.clj
+++ b/list-reduction/josephus.clj
@@ -1,13 +1,17 @@
-(defn shout [counter nth coll]
-    (if (== (count coll) 1)
-        (first coll)
-        (shout
-            (rem (+ counter (count coll)) nth)
-            nth
-            (keep-indexed #(if(not= 0 (rem (+ %1 counter) nth)) %2) coll))))
+(defn shout ^long [counter nth coll]
+  (let [cnt (count coll)]
+    (if (= 1 cnt)
+      (first coll)
+      (shout (rem (+ counter cnt) nth)
+             nth
+             (keep-indexed (fn [index item]
+                             (when-not (zero? (rem (+ index counter)
+                                                   nth))
+                               item))
+                           coll)))))
 
 (defn josephus [people nth]
-  (shout 0 nth (range 1 (inc people))))
+  (shout 0 nth (into [] (range 1 (inc people)))))
 
 (defn run-iterations [iterations times]
   (dotimes [_ times]


### PR DESCRIPTION
This runs in 41% of the time of your current implementation.

mine:
java -server -cp ~/code/playground-master/lib/clojure-1.3.0-beta1.jar clojure.main ~/tmp/josephus/list-reduction/josephus.clj
26
6.8059125
6.3941145

> java -server -cp ~/code/playground-master/lib/clojure-1.3.0-beta1.jar clojure.main ~/tmp/josephus/list-reduction/josephus.clj
> 26
> 16.172403
> 15.573797
> 15.541081
